### PR TITLE
Adjust Traefik Service for schedule on 'manager'

### DIFF
--- a/docker-compose-ingress.yml
+++ b/docker-compose-ingress.yml
@@ -10,6 +10,10 @@ services:
       - "3030:8080" # The Web UI (enabled by --api)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
     networks:
       - metrics-net
       - traefik-net


### PR DESCRIPTION
The Traefik service should always run on manager nodes. For this I added a "Placement Constraint".